### PR TITLE
Add option to set node parameters with rospy.get_param() and add launchfile

### DIFF
--- a/launch/rospicam_node.launch
+++ b/launch/rospicam_node.launch
@@ -1,0 +1,8 @@
+<launch>
+  <node pkg="rospicam" name="rospicam" type="rospicam_node.py" output="screen">
+    <rosparam>
+      framerate: 30
+      resolution: [640, 480]
+    </rosparam>
+  </node>
+</launch>

--- a/src/rospicam_node.py
+++ b/src/rospicam_node.py
@@ -10,19 +10,22 @@ from sensor_msgs.msg import CompressedImage
 
 class RosPiCam:
     def __init__(self):
-        print "rospicam start"
 
         # publishers
-        self.image_pub = rospy.Publisher('/rospicam/image/compressed', CompressedImage, queue_size=10)
+        self.image_pub = rospy.Publisher('/rospicam/image/compressed', CompressedImage, queue_size=1)
 
         # init the node
         rospy.init_node('rospicam', anonymous=True)
 
+        rospy.loginfo("rospicam start")
+
         stream = BytesIO()
         camera = PiCamera()
-        camera.resolution = (640, 480)
-        camera.framerate = 30
-        
+        resolution = rospy.get_param('~resolution', [640, 480])
+        camera.resolution = resolution
+        framerate_hz = float(rospy.get_param('~framerate', 30))
+        camera.framerate = framerate_hz
+
         for foo in camera.capture_continuous(stream, format='jpeg', use_video_port=True):
             stream.truncate()
             stream.seek(0)
@@ -35,7 +38,7 @@ class RosPiCam:
         stream.close()
         camera.close()
 
-        print "rospicam stop"
+        rospy.loginfo("rospicam stop")
 
     def publish_image(self, stream):
         image_msg = CompressedImage()


### PR DESCRIPTION

The two camera parameters "resolution" and "framerate" are not hard-coded
any more and can now be adjusted dynamically using the parameter server.
Also added as sample launchfile.
Other minor modifications:
Changed queue size (FIFO queue) to 1 as it is presumed to introduce delay.